### PR TITLE
External client support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ bytes = "1.4.0"
 futures-util = "0.3.27"
 lazy_static = "1.4.0"
 reqwest = { features = ["json", "stream"], version = "0.11.14"}
+reqwest-traits = "0.2.0"
 serde = {features = ["derive"], version = "1.0.157"}
 serde_json = "1.0.94"
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -92,6 +92,6 @@ pub async fn external_client() {
         .user_agent("My cool program")
         .build()
         .unwrap();
-    let c = openai_rust::Client::new_with_client(&KEY, req_c);
+    let c = openai_rust::ClientWithReqwest::new(&KEY, req_c);
     c.list_models().await.unwrap();
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,7 +1,7 @@
 use futures_util::StreamExt;
+use lazy_static::lazy_static;
 use openai_rust;
 use std::env::var;
-use lazy_static::lazy_static;
 
 lazy_static! {
     static ref KEY: String = var("OPENAI_API_KEY").unwrap();
@@ -16,38 +16,50 @@ pub async fn list_models() {
 #[tokio::test]
 pub async fn create_chat() {
     let c = openai_rust::Client::new(&KEY);
-    let args = openai_rust::chat::ChatArguments::new("gpt-3.5-turbo", vec![
-        openai_rust::chat::Message {
+    let args = openai_rust::chat::ChatArguments::new(
+        "gpt-3.5-turbo",
+        vec![openai_rust::chat::Message {
             role: "user".to_owned(),
             content: "Hello GPT!".to_owned(),
-        }
-    ]);
+        }],
+    );
     c.create_chat(args).await.unwrap();
 }
 
 #[tokio::test]
 pub async fn create_chat_stream() {
     let c = openai_rust::Client::new(&KEY);
-    let args = openai_rust::chat::ChatArguments::new("gpt-3.5-turbo", vec![
-        openai_rust::chat::Message {
+    let args = openai_rust::chat::ChatArguments::new(
+        "gpt-3.5-turbo",
+        vec![openai_rust::chat::Message {
             role: "user".to_owned(),
             content: "Hello GPT!".to_owned(),
-        }
-    ]);
-    c.create_chat_stream(args).await.unwrap().collect::<Vec<_>>().await;
+        }],
+    );
+    c.create_chat_stream(args)
+        .await
+        .unwrap()
+        .collect::<Vec<_>>()
+        .await;
 }
 
 #[tokio::test]
 pub async fn create_completion() {
     let c = openai_rust::Client::new(&KEY);
-    let args = openai_rust::completions::CompletionArguments::new("text-davinci-003", "The quick brown fox".to_owned());
+    let args = openai_rust::completions::CompletionArguments::new(
+        "text-davinci-003",
+        "The quick brown fox".to_owned(),
+    );
     c.create_completion(args).await.unwrap();
 }
 
 #[tokio::test]
 pub async fn create_completion_logprobs() {
     let c = openai_rust::Client::new(&KEY);
-    let mut args = openai_rust::completions::CompletionArguments::new("text-davinci-003", "The quick brown fox".to_owned());
+    let mut args = openai_rust::completions::CompletionArguments::new(
+        "text-davinci-003",
+        "The quick brown fox".to_owned(),
+    );
     args.logprobs = Some(1);
     c.create_completion(args).await.unwrap();
 }
@@ -55,13 +67,31 @@ pub async fn create_completion_logprobs() {
 #[tokio::test]
 pub async fn create_edit() {
     let c = openai_rust::Client::new(&KEY);
-    let args = openai_rust::edits::EditArguments::new("text-davinci-edit-001", "The quick brown fox".to_owned(), "Complete this sentence.".to_owned());
+    let args = openai_rust::edits::EditArguments::new(
+        "text-davinci-edit-001",
+        "The quick brown fox".to_owned(),
+        "Complete this sentence.".to_owned(),
+    );
     c.create_edit(args).await.unwrap();
 }
 
 #[tokio::test]
 pub async fn create_embeddings() {
     let c = openai_rust::Client::new(&KEY);
-    let args = openai_rust::embeddings::EmbeddingsArguments::new("text-embedding-ada-002", "The food was delicious and the waiter...".to_owned());
+    let args = openai_rust::embeddings::EmbeddingsArguments::new(
+        "text-embedding-ada-002",
+        "The food was delicious and the waiter...".to_owned(),
+    );
     c.create_embeddings(args).await.unwrap();
+}
+
+#[tokio::test]
+pub async fn external_client() {
+    use reqwest;
+    let req_c = reqwest::ClientBuilder::new()
+        .user_agent("My cool program")
+        .build()
+        .unwrap();
+    let c = openai_rust::Client::new_with_client(&KEY, req_c);
+    c.list_models().await.unwrap();
 }


### PR DESCRIPTION
Continuing with #2

Trying it out, we couldn't inject a `reqwest_middleware::ClientWithMiddleware`, so I took a stab at creating a `reqwest-traits` to make this crate more extensible by accepting a trait rather than the specific type.

## What's the purpose of the PR?

Allowing injecting either `reqwest::Client` or `reqwest_middleware::ClientWithMiddleware`.

Use cases:
* Support tracing of requests with `[reqwest-tracing](https://crates.io/crates/reqwest-tracing)`
* Use `[rvcr](https://crates.io/crates/rvcr)` for testing, which means tests are not constantly hitting OpenAI's APIs and costing money.

## How it's implemented

* Rename `Client` to a generic `ClientWithReqwest<request_traits::Client>`
* Define a newtype `Client(ClientWithReqwest<request::Client>)` so changes are backwards compatible.

There are some unrelated changes from `rust-fmt`. I hope that's OK! My editor is set up to format files when saving.