### PR TITLE
embeddings: input should be array of strings

### DIFF
--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -17,14 +17,14 @@ pub struct EmbeddingsArguments {
     /// ID of the model to use. You can use the [List models](crate::Client::list_models) API to see all of your available models, or see our [Model overview](https://platform.openai.com/docs/models/overview) for descriptions of them.
     pub model: String,
     /// Input text to embed, encoded as a string or array of tokens. To embed multiple inputs in a single request, pass an array of strings or array of token arrays. Each input must not exceed the max input tokens for the model (8191 tokens for `text-embedding-ada-002`). [Example Python code](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb) for counting tokens.
-    pub input: String,
+    pub input: Vec<String>,
     /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
 }
 
 impl EmbeddingsArguments {
-    pub fn new(model: impl AsRef<str>, input: String) -> EmbeddingsArguments {
+    pub fn new(model: impl AsRef<str>, input: Vec<String>) -> EmbeddingsArguments {
         EmbeddingsArguments {
             model: model.as_ref().to_owned(),
             input,


### PR DESCRIPTION
The embedding module did not work as-is because the API takes an array of strings, not a single string.